### PR TITLE
Fix > not working on OSX without rm first

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1008,6 +1008,7 @@ serialize_segment() {
   fi
 
   local FILE="${CACHE_DIR}/p9k_$$_${ALIGNMENT}_${(l:3::0:)INDEX}_${NAME}.sh"
+  rm -f $FILE #Remove the previous file prior, due to weird > handling on OS X
   typeset -p "NAME" > $FILE
   typeset -p "STATE" >> $FILE
   typeset -p "ALIGNMENT" >> $FILE


### PR DESCRIPTION
When doing ">" to a file that already exists, OS X fails (at least for me) with errors like:
```
serialize_segment:54: file exists: /tmp/p9k/p9k_53225_left_001_prompt_os_icon.sh
serialize_segment:54: file exists: /tmp/p9k/p9k_53225_left_003_prompt_time.sh
serialize_segment:54: file exists: /tmp/p9k/p9k_53225_left_002_prompt_context.sh
serialize_segment:54: file exists: /tmp/p9k/p9k_53225_right_001_prompt_status.sh
serialize_segment:54: file exists: /tmp/p9k/p9k_53225_left_004_prompt_dir.sh
serialize_segment:54: file exists: /tmp/p9k/p9k_53225_right_003_prompt_ip.sh
serialize_segment:54: file exists: /tmp/p9k/p9k_53225_right_004_prompt_battery.sh
```
this removes the previous file before trying to pipe to it, to circumvent this.
