### PR TITLE
editorconfig: trim trailing spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
+# EditorConfig: http://EditorConfig.org
+
+root = true
+
 [*]
 charset = utf-8
 end_of_line = lf
@@ -5,7 +9,11 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 
-[*.spec]
-# Unfortunately, we sometime need trailing whitespace in tests.
-# @see test/core/prompt.spec
-trim_trailing_whitespace = false
+[*.md]
+max_line_length = off
+indent_size = 4
+trim_trailing_whitespace = true
+
+[{*.spec,*.zsh,*.zsh-theme}]
+# Specific hack for (Neo)Vim filetype detection
+vim_filetype = zsh

--- a/test/core/prompt.spec
+++ b/test/core/prompt.spec
@@ -94,9 +94,8 @@ function testLeftMultilinePrompt() {
     writeCacheFile "1" "left" "false" "true"
     p9k_build_prompt_from_cache
 
-    # Caution! Trailing whitespace is important here!
-    assertEquals "╭─%f%b%k%K{blue} %F{black}segment_1_content %k%F{blue}%f 
-╰─ " "${PROMPT}"
+    local nl=$'\n'
+    assertEquals "╭─%f%b%k%K{blue} %F{black}segment_1_content %k%F{blue}%f ${nl}╰─ " "${PROMPT}"
 
     unset POWERLEVEL9K_PROMPT_ON_NEWLINE
     unset POWERLEVEL9K_MULTILINE_FIRST_PROMPT_PREFIX
@@ -129,9 +128,8 @@ function testPrefixingFirstLineOnLeftPrompt() {
     writeCacheFile "1" "left" "false" "true"
     p9k_build_prompt_from_cache
 
-    # Caution! Trailing whitespace is important here!
-    assertEquals "XXX%f%b%k%K{blue} %F{black}segment_1_content %k%F{blue}%f 
-╰─ " "${PROMPT}"
+    local nl=$'\n'
+    assertEquals "XXX%f%b%k%K{blue} %F{black}segment_1_content %k%F{blue}%f ${nl}╰─ " "${PROMPT}"
 
 
     unset POWERLEVEL9K_PROMPT_ON_NEWLINE
@@ -145,9 +143,8 @@ function testPrefixingSecondLineOnLeftPrompt() {
     writeCacheFile "1" "left" "false" "true"
     p9k_build_prompt_from_cache
 
-    # Caution! Trailing whitespace is important here!
-    assertEquals "╭─%f%b%k%K{blue} %F{black}segment_1_content %k%F{blue}%f 
-XXX" "${PROMPT}"
+    local nl=$'\n'
+    assertEquals "╭─%f%b%k%K{blue} %F{black}segment_1_content %k%F{blue}%f ${nl}XXX" "${PROMPT}"
 
     unset POWERLEVEL9K_PROMPT_ON_NEWLINE
     unset POWERLEVEL9K_MULTILINE_SECOND_PROMPT_PREFIX

--- a/test/segments/symfony_version.spec
+++ b/test/segments/symfony_version.spec
@@ -110,7 +110,7 @@ function testSymfonyVersionSegmentWorks() {
 function testSymfonyVersionSegmentWorksInNestedFolder() {
     mkdir app
     touch app/AppKernel.php
-    
+
     function php() {
         echo "Symfony version 3.1.4 - app/dev/debug"
     }


### PR DESCRIPTION
- Fixed the issues in test/core/prompt.spec
- Added `root = true`
- Added URL on info about EditorConfig