### PR TITLE
Fix iteration in render

### DIFF
--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -366,15 +366,27 @@ function __p9k_build_segment_cache() {
 
 ###############################################################
 # @description
-#   Refresh a single item in the cache
+#   Refresh a single item/segment in the cache
 ##
 # @args
-#   $1 string The serialized segment data
+#   $1 segment name
+#   $2 boolean true to trigger prompt rendering
 ##
 function __p9k_refresh_cache_item() {
-  local -a segment_meta=("${(@s:·|·:)1}")
+  local segment="$1"
+  local alignment index joined segmentMetaVar cache_key
+  for alignment in left right; do
+    for index in $(p9k::find_in_array "${segment}" "${__P9K_DATA[${alignment}_segments]}"); do
+      joined=false
+      segmentMetaVar="P9K_${(U)alignment}_PROMPT_ELEMENTS[${index}]"
+      p9k::segment_is_tagged_as "joined" ${${(P)segmentMetaVar}%%::*} && joined=true
+      cache_key="${alignment}::${index}"
+      prompt_${segment} "${alignment}" "$index" "${joined}"
+      __p9k_segment_cache["${cache_key}"]="${__P9K_DATA[SEGMENT_RESULT]}"
+    done
+  done
 
-  __p9k_segment_cache["${segment_meta[2]}::${segment_meta[3]}"]="${1}"
+  [[ $2 == "true" ]] && __p9k_render "true"
 }
 
 ###############################################################

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -434,8 +434,10 @@ function __p9k_render() {
   # to avoid double expansion of the contents of the PROMPT.
   typeset -gAh __p9k_unsafe=()
 
+  local cache_key data
   # Process Cache
-  for data in "${(Oa@v)__p9k_segment_cache}"; do
+  for cache_key in "${(o@kn)__p9k_segment_cache}"; do
+    data="${__p9k_segment_cache[${cache_key}]}"
     [[ -z "${data}" ]] && continue
 
     local -a segment_meta=("${(@s:·|·:)data}")

--- a/segments/vi_mode/vi_mode.p9k
+++ b/segments/vi_mode/vi_mode.p9k
@@ -77,17 +77,7 @@ prompt_vi_mode() {
 
 function rebuildViMode() {
   # Re-Init segment
-  for alignment in left right; do
-    for index in $(p9k::find_in_array "vi_mode" "${__P9K_DATA[${alignment}_segments]}"); do
-      local joined=false
-      local segmentMetaVar="P9K_${(U)alignment}_PROMPT_ELEMENTS[${index}]"
-      p9k::segment_is_tagged_as "joined" ${${(P)segmentMetaVar}%%::*} && joined=true
-      prompt_vi_mode "${alignment}" "${index}" "${joined}"
-      __p9k_refresh_cache_item "${__P9K_DATA[SEGMENT_RESULT]}"
-    done
-  done
-
-  __p9k_render "true"
+  __p9k_refresh_cache_item "vi_mode" "true"
 }
 
 ###############################################################


### PR DESCRIPTION
Iterate based on segment sequence from PROMPT_ELEMENTS arrays in `__p9k_render`. To make it work, keys in associate array `__p9k_segment_cache` are set as `cache_key="${alignment}::${segment}"`. 

With above change, cache update in `vi_mode` is reorganized. All the single item cache update steps are separated into `__p9k_refresh_cache_item`.

```zsh
__p9k_refresh_cache_item "vi_mode" "true"
```

```zsh
###############################################################
# @description
#   Refresh a single item/segment in the cache
##
# @args
#   $1 segment name
#   $2 boolean true to trigger prompt rendering
##
function __p9k_refresh_cache_item() {
...
```

Additional work is done in `__p9k_async_wrapper` to pass `segment` name into callback. Otherwise, the `segment` value from `__p9k_segment_cache` may be transformed as `STATEFUL_NAME`.