### PR TITLE
Async with segment untouched

### DIFF
--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -366,15 +366,27 @@ function __p9k_build_segment_cache() {
 
 ###############################################################
 # @description
-#   Refresh a single item in the cache
+#   Refresh a single item/segment in the cache
 ##
 # @args
-#   $1 string The serialized segment data
+#   $1 segment name
+#   $2 boolean true to trigger prompt rendering
 ##
 function __p9k_refresh_cache_item() {
-  local -a segment_meta=("${(@s:·|·:)1}")
+  local segment="$1"
+  local alignment index joined segmentMetaVar cache_key
+  for alignment in left right; do
+    for index in $(p9k::find_in_array "${segment}" "${__P9K_DATA[${alignment}_segments]}"); do
+      joined=false
+      segmentMetaVar="P9K_${(U)alignment}_PROMPT_ELEMENTS[${index}]"
+      p9k::segment_is_tagged_as "joined" ${${(P)segmentMetaVar}%%::*} && joined=true
+      cache_key="${alignment}::${index}"
+      prompt_${segment} "${alignment}" "$index" "${joined}"
+      __p9k_segment_cache["${cache_key}"]="${__P9K_DATA[SEGMENT_RESULT]}"
+    done
+  done
 
-  __p9k_segment_cache["${segment_meta[2]}::${segment_meta[3]}"]="${1}"
+  [[ $2 == "true" ]] && __p9k_render "true"
 }
 
 ###############################################################

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -434,8 +434,10 @@ function __p9k_render() {
   # to avoid double expansion of the contents of the PROMPT.
   typeset -gAh __p9k_unsafe=()
 
+  local cache_key data
   # Process Cache
-  for data in "${(Oa@v)__p9k_segment_cache}"; do
+  for cache_key in "${(o@kn)__p9k_segment_cache}"; do
+    data="${__p9k_segment_cache[${cache_key}]}"
     [[ -z "${data}" ]] && continue
 
     local -a segment_meta=("${(@s:·|·:)data}")

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -248,28 +248,6 @@ function p9k::prepare_segment() {
 
 ################################################################
 # @description
-#   Helper function to enable early exit for segments.
-##
-# @args
-#   $1 string Name of the function that was originally invoked (mandatory)
-#   $2 string State of the segment
-#   $3 string Alignment (left|right)
-#   $4 integer Index of the segment
-#   $5 bool Whether the segment should be joined
-##
-function p9k::segment_no_print() {
-  local STATEFUL_NAME="${${(U)1}#PROMPT_}"
-  [[ -n "${2}" ]] && STATEFUL_NAME="${STATEFUL_NAME}_${(U)2}"
-
-  local alignment="${3}"
-  local index="${4}"
-  local joined="${5}"
-
-  __P9K_DATA[SEGMENT_RESULT]="${STATEFUL_NAME}·|·${alignment}·|·${index}·|·${joined}·|··|··|·false"
-}
-
-################################################################
-# @description
 #   The `custom` prompt provides a way for users to invoke commands and display
 #   the output in a segment.
 ##
@@ -298,6 +276,9 @@ function __p9k_prompt_custom() {
 ##
 function __p9k_async_wrapper() {
   local command="${1}"
+  # Disable the segment to be disabled and pre-empty placesholder.
+  __P9K_DATA[SEGMENT_RESULT]="${1#prompt_}·|·${2}·|·${3}·|·${4}·|··|··|·false"
+
   shift
   ${command} "$@"
 

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -327,6 +327,8 @@ function __p9k_build_segment_cache() {
       # Placeholder
       __p9k_segment_cache["${cache_key}"]="${segment}·|·${alignment}·|·${index}·|·${joined}·|·…·|··|·true"
     elif ${custom}; then
+      # Assume a segment is not going to be displayed by default
+      __P9K_DATA[SEGMENT_RESULT]="${segment}·|·${alignment}·|·${index}·|·${joined}·|··|··|·false"
       __p9k_prompt_custom "${alignment}" "${index}" "${joined}" "${segment}"
       __p9k_segment_cache["${cache_key}"]="${__P9K_DATA[SEGMENT_RESULT]}"
     elif ${async}; then
@@ -336,6 +338,8 @@ function __p9k_build_segment_cache() {
       __p9k_segment_cache["${cache_key}"]="${segment}·|·${alignment}·|·${index}·|·${joined}·|·…·|··|·true"
     else
       # TODO: Skip computation if cache is fresh for some segments?
+      # Assume a segment is not going to be displayed by default
+      __P9K_DATA[SEGMENT_RESULT]="${segment}·|·${alignment}·|·${index}·|·${joined}·|··|··|·false"
       prompt_${segment} "${alignment}" "$index" "${joined}"
       __p9k_segment_cache["${cache_key}"]="${__P9K_DATA[SEGMENT_RESULT]}"
     fi

--- a/segments/anaconda/anaconda.p9k
+++ b/segments/anaconda/anaconda.p9k
@@ -33,7 +33,7 @@ prompt_anaconda() {
   # Depending on the conda version, either might be set. This
   # variant works even if both are set.
   local _path=$CONDA_ENV_PATH$CONDA_PREFIX
-
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "$P9K_ANACONDA_LEFT_DELIMITER${_path:t}$P9K_ANACONDA_RIGHT_DELIMITER" \
-      "[[ -n \"${_path}\" ]]"
+  if ! [ -z "$_path" ]; then
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "$P9K_ANACONDA_LEFT_DELIMITER${_path:t}$P9K_ANACONDA_RIGHT_DELIMITER"
+  fi
 }

--- a/segments/aws/aws.p9k
+++ b/segments/aws/aws.p9k
@@ -27,5 +27,7 @@
 prompt_aws() {
   local aws_profile="${AWS_PROFILE:-$P9K_AWS_DEFAULT_PROFILE}"
 
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "$aws_profile"
+  if [[ -n "$aws_profile" ]]; then
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "$aws_profile"
+  fi
 }

--- a/segments/aws_eb_env/aws_eb_env.p9k
+++ b/segments/aws_eb_env/aws_eb_env.p9k
@@ -27,5 +27,7 @@
 prompt_aws_eb_env() {
   local eb_env=${${(s: :)$(grep environment .elasticbeanstalk/config.yml 2> /dev/null)}[2]}
 
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "$eb_env"
+  if [[ -n "$eb_env" ]]; then
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "$eb_env"
+  fi
 }

--- a/segments/background_jobs/background_jobs.p9k
+++ b/segments/background_jobs/background_jobs.p9k
@@ -49,9 +49,7 @@ prompt_background_jobs() {
       else
         jobs_print="${total_jobs}"
       fi
+      p9k::prepare_segment "$0" "" $1 "$2" $3 "${jobs_print}"
     fi
   fi
-
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "${jobs_print}" \
-      "[[ ${(L)P9K_BACKGROUND_JOBS_VERBOSE_ALWAYS} == true ]] || (( ${total_jobs} > 0 ))"
 }

--- a/segments/battery/battery.p9k
+++ b/segments/battery/battery.p9k
@@ -47,7 +47,6 @@ prompt_battery() {
     raw_data=${raw_data[2]}
     # return if there is no battery on system
     [[ ! $raw_data =~ "InternalBattery" ]] && \
-        p9k::segment_no_print "${0}" "" "${1}" "${2}" "${3}" && \
         return
 
     # Time remaining on battery operation (charging/discharging)
@@ -110,7 +109,7 @@ prompt_battery() {
       3) current_state='charged';;
       4 | 5) current_state='low';;
       6 | 7 | 8 | 9 | 11) current_state='charging';;
-      10 | *) p9k::segment_no_print "${0}" "${(U)current_state}" "${1}" "${2}" "${3}" && return;;
+      10 | *) return;;
     esac
   fi
 
@@ -119,7 +118,7 @@ prompt_battery() {
     local sysp="${ROOT_PREFIX}/sys/class/power_supply"
     local -a bats
     bats=( $sysp/(BAT*|battery)(N) )
-    [[ ${#bats} == 0 ]] && p9k::segment_no_print "${0}" "${(U)current_state}" "${1}" "${2}" "${3}" && return
+    [[ ${#bats} == 0 ]] && return
 
     local energy_now="0"
     local energy_full="0"
@@ -195,7 +194,7 @@ prompt_battery() {
 
   # return if P9K_BATTERY_HIDE_ABOVE_THRESHOLD is set and the battery percentage is greater or equal
   if p9k::defined P9K_BATTERY_HIDE_ABOVE_THRESHOLD && [[ "${bat_percent}" -ge $P9K_BATTERY_HIDE_ABOVE_THRESHOLD ]]; then
-    p9k::segment_no_print "${0}" "${(U)current_state}" "${1}" "${2}" "${3}" && return
+    return
   fi
 
   local message

--- a/segments/battery/battery.p9k
+++ b/segments/battery/battery.p9k
@@ -46,8 +46,7 @@ prompt_battery() {
     # use only second line
     raw_data=${raw_data[2]}
     # return if there is no battery on system
-    [[ ! $raw_data =~ "InternalBattery" ]] && \
-        return
+    [[ ! $raw_data =~ "InternalBattery" ]] && return
 
     # Time remaining on battery operation (charging/discharging)
     local tstring=${${(s: :)${${(s:; :)raw_data}[3]}}[1]}

--- a/segments/chruby/chruby.p9k
+++ b/segments/chruby/chruby.p9k
@@ -46,6 +46,7 @@ prompt_chruby() {
   chruby_label="${chruby_label%"${chruby_label##*[![:space:]]}"}"
 
   # Don't show anything if the chruby did not change the default ruby
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "${chruby_label}" \
-      "[[ -n \"${RUBY_ENGINE}\" ]]"
+  if [[ "$RUBY_ENGINE" != "" ]]; then
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "${chruby_label}"
+  fi
 }

--- a/segments/command_execution_time/command_execution_time.p9k
+++ b/segments/command_execution_time/command_execution_time.p9k
@@ -45,8 +45,6 @@ prompt_command_execution_time() {
       # If the command executed in seconds, round to desired precision and append "s"
       humanReadableDuration=$(printf %.${P9K_COMMAND_EXECUTION_TIME_PRECISION}f%s $_P9K_COMMAND_DURATION s)
     fi
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "${humanReadableDuration}"
   fi
-
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "${humanReadableDuration}" \
-      "(( _P9K_COMMAND_DURATION >= P9K_COMMAND_EXECUTION_TIME_THRESHOLD ))"
 }

--- a/segments/context/context.p9k
+++ b/segments/context/context.p9k
@@ -46,6 +46,8 @@ prompt_context() {
     content="${P9K_CONTEXT_TEMPLATE}"
   elif [[ "$P9K_CONTEXT_ALWAYS_SHOW_USER" == true ]]; then
     content="${me}"
+  else
+    return
   fi
 
   if [[ $(print -P "%#") == '#' ]]; then

--- a/segments/detect_virt/detect_virt.p9k
+++ b/segments/detect_virt/detect_virt.p9k
@@ -29,6 +29,5 @@ prompt_detect_virt() {
   if [[ "$virt" == "none" ]]; then
     [[ "$(ls -di / | grep -o 2)" != "2" ]] && virt="chroot"
   fi
-
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "$virt"
+  [[ -n "${virt}" ]] && p9k::prepare_segment "$0" "" $1 "$2" $3 "$virt"
 }

--- a/segments/dir_writable/dir_writable.p9k
+++ b/segments/dir_writable/dir_writable.p9k
@@ -25,6 +25,7 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_dir_writable() {
-  p9k::prepare_segment "$0" "FORBIDDEN" $1 "$2" $3 "" \
-      "[[ ! -w \"${PWD}\" ]]"
+  if [[ ! -w "$PWD" ]]; then
+    p9k::prepare_segment "$0" "FORBIDDEN" $1 "$2" $3 "" "[[ true ]]"
+  fi
 }

--- a/segments/disk_usage/disk_usage.p9k
+++ b/segments/disk_usage/disk_usage.p9k
@@ -45,18 +45,17 @@ prompt_disk_usage() {
         current_state='critical'
     fi
   else
-    current_state='normal'
     if [[ "$P9K_DISK_USAGE_ONLY_WARNING" == true ]]; then
         current_state=''
-        # Avoid printing the prompt, by setting $disk_usage
-        # to empty string, so the condition is not fulfilled.
-        disk_usage=''
+        return
     fi
+    current_state='normal'
   fi
 
   local message="${disk_usage}%%"
 
   # Draw the prompt_segment
-  p9k::prepare_segment "$0" "${current_state}" $1 "$2" $3 "$message" \
-      "[[ -n \"${disk_usage}\" ]]"
+  if [[ -n ${disk_usage} ]]; then
+    p9k::prepare_segment "$0" "${current_state}" $1 "$2" $3 "$message"
+  fi
 }

--- a/segments/docker_machine/docker_machine.p9k
+++ b/segments/docker_machine/docker_machine.p9k
@@ -25,5 +25,5 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_docker_machine() {
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "${DOCKER_MACHINE_NAME}"
+  [[ -n "${DOCKER_MACHINE_NAME}" ]] && p9k::prepare_segment "$0" "" $1 "$2" $3 "${DOCKER_MACHINE_NAME}"
 }

--- a/segments/dropbox/dropbox.p9k
+++ b/segments/dropbox/dropbox.p9k
@@ -29,11 +29,13 @@ prompt_dropbox() {
   local dropbox_status="$(dropbox-cli filestatus . | cut -d\  -f2-)"
 
   # Only show if the folder is tracked and dropbox is running
-  # If "up to date", only show the icon
-  if [[ "$dropbox_status" =~ 'up to date' ]]; then
-    dropbox_status=" "
+  if [[ "$dropbox_status" != 'unwatched' && "$dropbox_status" != "isn't running!" ]]; then
+    # If "up to date", only show the icon
+    if [[ "$dropbox_status" =~ 'up to date' ]]; then
+      dropbox_status=" "
+    fi
+
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "$dropbox_status"
   fi
 
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "$dropbox_status" \
-      "[[ \"${dropbox_status}\" != 'unwatched' && \"${dropbox_status}\" != \"isn't running!\" ]]"
 }

--- a/segments/gitstatus/gitstatus.p9k
+++ b/segments/gitstatus/gitstatus.p9k
@@ -91,8 +91,7 @@ prompt_gitstatus() {
   gitstatus_query -d ${${GIT_DIR:a}:-$PWD} -t $P9K_GITSTATUS_MAX_SYNC_LATENCY_SECONDS P9K 2>/dev/null
 
   # Print nothing, if we are not in a repo, or if the gitstatus daemon sends a timeout
-  [[ ! "${VCS_STATUS_RESULT}" =~ "ok-*" && "${VCS_STATUS_RESULT}" != 'tout' ]] && \
-      return
+  [[ ! "${VCS_STATUS_RESULT}" =~ "ok-*" && "${VCS_STATUS_RESULT}" != 'tout' ]] && return
 
   local current_state="CLEAN"
   typeset -ah segment_content

--- a/segments/gitstatus/gitstatus.p9k
+++ b/segments/gitstatus/gitstatus.p9k
@@ -92,7 +92,6 @@ prompt_gitstatus() {
 
   # Print nothing, if we are not in a repo, or if the gitstatus daemon sends a timeout
   [[ ! "${VCS_STATUS_RESULT}" =~ "ok-*" && "${VCS_STATUS_RESULT}" != 'tout' ]] && \
-      p9k::segment_no_print "${0}" "" "${1}" "${2}" "${3}" && \
       return
 
   local current_state="CLEAN"

--- a/segments/go_version/go_version.p9k
+++ b/segments/go_version/go_version.p9k
@@ -30,6 +30,7 @@ prompt_go_version() {
   go_version=$(go version 2>/dev/null | sed -E "s/.*(go[0-9.]*).*/\1/")
   go_path=$(go env GOPATH 2>/dev/null)
 
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "$go_version" \
-      "[[ -n \"${go_version}\" && \"${PWD##$go_path}\" != \"${PWD}\" ]]"
+  if [[ -n "$go_version" && "${PWD##$go_path}" != "$PWD" ]]; then
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "$go_version"
+  fi
 }

--- a/segments/java_version/java_version.p9k
+++ b/segments/java_version/java_version.p9k
@@ -32,6 +32,7 @@ prompt_java_version() {
   # If yes, we parse the version string (and need to
   # redirect the stderr to stdout to make the pipe work).
   java_version=$(java -version 2>/dev/null && java -fullversion 2>&1 | cut -d '"' -f 2)
-
-  p9k::prepare_segment "$0" "" $1 "$2" $3  "${java_version}"
+  if [[ -n "$java_version" ]]; then
+    p9k::prepare_segment "$0" "" $1 "$2" $3  "${java_version}"
+  fi
 }

--- a/segments/kubecontext/kubecontext.p9k
+++ b/segments/kubecontext/kubecontext.p9k
@@ -26,7 +26,6 @@
 ##
 prompt_kubecontext() {
   local kubectl_version="$(kubectl version --client 2>/dev/null)"
-  local k8s_final_text=""
 
   if [[ -n "$kubectl_version" ]]; then
     # Get the current Kuberenetes context
@@ -37,6 +36,8 @@ prompt_kubecontext() {
       cur_namespace="default"
     fi
 
+    local k8s_final_text=""
+
     if [[ "$cur_ctx" == "$cur_namespace" ]]; then
       # No reason to print out the same identificator twice
       k8s_final_text="$cur_ctx"
@@ -44,7 +45,6 @@ prompt_kubecontext() {
       k8s_final_text="$cur_ctx/$cur_namespace"
     fi
 
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "$k8s_final_text"
   fi
-
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "$k8s_final_text"
 }

--- a/segments/laravel_version/laravel_version.p9k
+++ b/segments/laravel_version/laravel_version.p9k
@@ -26,10 +26,10 @@
 ##
 prompt_laravel_version() {
   local laravel_version="$(php artisan --version 2> /dev/null)"
+  if [[ -n "${laravel_version}" && "${laravel_version}" =~ "Laravel Framework" ]]; then
+    # Strip out everything but the version
+    laravel_version="${laravel_version//Laravel Framework /}"
 
-  # Strip out everything but the version
-  laravel_version="${laravel_version//Laravel Framework /}"
-
-  p9k::prepare_segment "${0}" "" "${1}" "${2}" "${3}" "${laravel_version}" \
-      "[[ -n \"${laravel_version}\" && \"${laravel_version}\" =~ \"Laravel Framework\" ]]"
+    p9k::prepare_segment "${0}" "" "${1}" "${2}" "${3}" "${laravel_version}"
+  fi
 }

--- a/segments/newline/newline.p9k
+++ b/segments/newline/newline.p9k
@@ -17,14 +17,13 @@
 #   This is not an actual prompt segment, it is just a workaround to allow more newlines in your prompt.
 ##
 prompt_newline() {
+  [[ "$1" == "right" ]] && return
+
   local newline=$'\n'
   [[ "${P9K_PROMPT_ON_NEWLINE:-}" == true ]] \
       && newline="${newline}${__P9K_ICONS[MULTILINE_NEWLINE_PROMPT_PREFIX]}"
 
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "${newline}" \
-      "[[ \"${1}\" == \"left\" ]]" \
-      "" \
-      "%k"
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "${newline}" "[[ true ]]" "" "%k"
   # Reset color variable, so that next segment starts as first
   CURRENT_BG="NONE"
 }

--- a/segments/node_version/node_version.p9k
+++ b/segments/node_version/node_version.p9k
@@ -26,6 +26,7 @@
 ##
 prompt_node_version() {
   local node_version=$(node -v 2>/dev/null)
+  [[ -z "${node_version}" ]] && return
 
   p9k::prepare_segment "$0" "" $1 "$2" $3 "${node_version:1}"
 }

--- a/segments/nodeenv/nodeenv.p9k
+++ b/segments/nodeenv/nodeenv.p9k
@@ -25,8 +25,8 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_nodeenv() {
-  local info="$(node -v)[${NODE_VIRTUAL_ENV:t}]"
-
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "$info" \
-      "[[ -n \"${NODE_VIRTUAL_ENV}\" ]]"
+  if [[ -n "$NODE_VIRTUAL_ENV" ]]; then
+    local info="$(node -v)[${NODE_VIRTUAL_ENV:t}]"
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "$info"
+  fi
 }

--- a/segments/nvm/nvm.p9k
+++ b/segments/nvm/nvm.p9k
@@ -28,22 +28,22 @@
 #   Only prints the segment if different than the default value.
 ##
 prompt_nvm() {
-  local node_version
-  local is_system=false
+  local node_version nvm_default is_system
+  is_system=false
+  (( $+functions[nvm_version] )) || return
 
-  node_version=$(nvm_version current 2>/dev/null)
-  if [[ -n "${node_version}" && ${node_version} != "none" ]]; then
-    if [[ "$node_version" == "system" ]]; then
-      node_version="$($(nvm which system) --version)"
-      is_system=true
-    fi
-    
-    local nvm_default=$(nvm_version default)
-    [[ "$node_version" == "$nvm_default" ]] && node_version=""
-
-    [[ "${node_version}" =~ "^v([0-9.]+)" ]] && node_version="${match[1]}"
-    [[ "$is_system" == true ]] && node_version="$node_version system"
+  node_version=$(nvm_version current)
+  [[ -z "${node_version}" || ${node_version} == "none" ]] && return
+  if [[ "$node_version" == "system" ]]; then
+    node_version="$($(nvm which system) --version)"
+    is_system=true
   fi
+
+  nvm_default=$(nvm_version default)
+  [[ "$node_version" =~ "$nvm_default" ]] && return
+
+  [[ "${node_version}" =~ "^v([0-9.]+)" ]] && node_version="${match[1]}"
+  [[ "$is_system" == true ]] && node_version="$node_version system"
 
   p9k::prepare_segment "$0" "" $1 "$2" $3 "$node_version"
 }

--- a/segments/openfoam/openfoam.p9k
+++ b/segments/openfoam/openfoam.p9k
@@ -27,12 +27,9 @@
 prompt_openfoam() {
   local wm_project_version="$WM_PROJECT_VERSION"
   local wm_fork="$WM_FORK"
-  local content
   if [[ -n "$wm_project_version" ]] &&  [[ -z "$wm_fork" ]] ; then
-    content="OF: ${wm_project_version:t}"
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "OF: ${wm_project_version:t}"
   elif [[ -n "$wm_project_version" ]] && [[ -n "$wm_fork" ]] ; then
-    content="F-X: ${wm_project_version:t}"
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "F-X: ${wm_project_version:t}"
   fi
-
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "${content}"
 }

--- a/segments/php_version/php_version.p9k
+++ b/segments/php_version/php_version.p9k
@@ -27,6 +27,7 @@
 prompt_php_version() {
   local php_version
   [[ "$(php -v 2>&1)" =~ "^PHP[[:blank:]]*([0-9.]+)" ]] && php_version="${match[1]}"
-
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "${php_version}"
+  if [[ -n "$php_version" ]]; then
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "${php_version}"
+  fi
 }

--- a/segments/public_ip/public_ip.p9k
+++ b/segments/public_ip/public_ip.p9k
@@ -106,7 +106,6 @@ prompt_public_ip() {
         icon="VPN_ICON"
       fi
     fi
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "${public_ip}" "" "$icon"
   fi
-
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "${public_ip}" "" "$icon"
 }

--- a/segments/pyenv/pyenv.p9k
+++ b/segments/pyenv/pyenv.p9k
@@ -32,19 +32,11 @@
 #   [Choosing the Python Version](https://github.com/pyenv/pyenv#choosing-the-python-version)
 ##
 prompt_pyenv() {
-  local pyenv_version_name
-  local pyenv_global
-  local pyenv_root
-
   if [ $commands[pyenv] ]; then
-    pyenv_version_name="$(pyenv version-name)"
-    pyenv_global="system"
-    pyenv_root="$(pyenv root)"
-    if [[ -f "${pyenv_root}/version" ]]; then
-      pyenv_global="$(pyenv version-file-read ${pyenv_root}/version)"
+    local pyenv_version_name="$(pyenv version-name 2>/dev/null)"
+    local pyenv_global="$(pyenv global)"
+    if [[ "${pyenv_version_name}" != "${pyenv_global}" || "${P9K_PYENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then
+      p9k::prepare_segment "$0" "" $1 "$2" $3 "${pyenv_version_name}"
     fi
   fi
-
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "${pyenv_version_name}" \
-      "[[ \"${pyenv_version_name}\" != \"${pyenv_global}\" || \"${P9K_PYENV_PROMPT_ALWAYS_SHOW}\" == \"true\" ]]"
 }

--- a/segments/rbenv/README.md
+++ b/segments/rbenv/README.md
@@ -17,10 +17,6 @@ It figures out the version being used by taking the output of the `rbenv version
 * If `rbenv` is not in $PATH, nothing will be shown.
 * By default, if the current local Ruby version is the same as the global Ruby version, nothing will be shown. See the configuration variable, below, to modify this behavior.
 
-Variable | Default Value | Description |
-|----------|---------------|-------------|
-|`P9K_RBENV_ALWAYS`|'false'|Always show the `rbenv` segment, even if the local version matches the global.|
-
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
 |`P9K_RBENV_PROMPT_ALWAYS_SHOW`|`false`|Set to true if you wish to show the rbenv segment even if the current Ruby version is the same as the global Ruby version|

--- a/segments/rbenv/rbenv.p9k
+++ b/segments/rbenv/rbenv.p9k
@@ -16,7 +16,7 @@
 
   ################################################################
   # Register segment default values
-  p9k::set_default P9K_RBENV_ALWAYS false
+  p9k::set_default P9K_RBENV_PROMPT_ALWAYS_SHOW false
 }
 
 ################################################################
@@ -29,14 +29,11 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_rbenv() {
-  local rbenv_version_name
-  local rbenv_global
-
   if [ ${commands[rbenv]} ]; then
-    rbenv_version_name="$(rbenv version-name)"
-    rbenv_global="$(rbenv global)"
+    local rbenv_version_name="$(rbenv version-name 2>/dev/null)"
+    local rbenv_global="$(rbenv global)"
+    if [[ "${rbenv_version_name}" != "${rbenv_global}" || "${P9K_RBENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then
+      p9k::prepare_segment "$0" "" $1 "$2" $3 "${rbenv_version_name}"
+    fi
   fi
-
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "${rbenv_version_name}" \
-      "[[ \"${rbenv_version_name}\" != \"${rbenv_global}\" || \"${P9K_RBENV_PROMPT_ALWAYS_SHOW}\" == \"true\" ]]"
 }

--- a/segments/root_indicator/root_indicator.p9k
+++ b/segments/root_indicator/root_indicator.p9k
@@ -25,6 +25,7 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_root_indicator() {
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "" \
-      "[[ \"${UID}\" -eq 0 ]]"
+  if [[ "$UID" -eq 0 ]]; then
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "" "[[ true ]]"
+  fi
 }

--- a/segments/rspec_stats/rspec_stats.p9k
+++ b/segments/rspec_stats/rspec_stats.p9k
@@ -30,13 +30,11 @@ source $__P9K_DIRECTORY/segments/test_stats.p9k
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_rspec_stats() {
-  local code_amount tests_amount
-  # Careful! `ls` seems to now work correctly with NULL_GLOB,
-  # as described here http://unix.stackexchange.com/a/26819
-  # This is the reason, why we do not use NULL_GLOB here.
-  code_amount=$({ls -1 app/**/*.rb} 2> /dev/null | wc -l)
-  tests_amount=$({ls -1 spec/**/*.rb} 2> /dev/null | wc -l)
+  if [[ (-d app && -d spec) ]]; then
+    local code_amount tests_amount
+    code_amount=$(ls -1 app/**/*.rb | wc -l)
+    tests_amount=$(ls -1 spec/**/*.rb | wc -l)
 
-  build_test_stats "$1" "$0" "$2" "${3}" "$code_amount" "$tests_amount" "RSpec" \
-      "[[ (-d app && -d spec && ${code_amound} -gt 0) ]]"
+    build_test_stats "$1" "$0" "$2" "$code_amount" "$tests_amount" "RSpec"
+  fi
 }

--- a/segments/rust_version/rust_version.p9k
+++ b/segments/rust_version/rust_version.p9k
@@ -32,5 +32,7 @@ prompt_rust_version() {
   # whitespace. This way we'll end up with only the version.
   rust_version=${${rust_version/rustc /}%% *}
 
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "$rust_version"
+  if [[ -n "$rust_version" ]]; then
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "$rust_version"
+  fi
 }

--- a/segments/rvm/rvm.p9k
+++ b/segments/rvm/rvm.p9k
@@ -28,5 +28,8 @@ prompt_rvm() {
   if [ $commands[rvm-prompt] ]; then
     local version_and_gemset=${$(rvm-prompt v p)/ruby-}
 
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "$version_and_gemset"
+    if [[ -n "$version_and_gemset" ]]; then
+      p9k::prepare_segment "$0" "" $1 "$2" $3 "$version_and_gemset"
+    fi
+  fi
 }

--- a/segments/ssh/ssh.p9k
+++ b/segments/ssh/ssh.p9k
@@ -25,6 +25,7 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_ssh() {
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "" \
-      "[[ -n \"${SSH_CLIENT}\" ]] || [[ -n \"${SSH_TTY}\" ]]"
+  if [[ -n "$SSH_CLIENT" ]] || [[ -n "$SSH_TTY" ]]; then
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "" "[[ true ]]"
+  fi
 }

--- a/segments/stack_project/stack_project.p9k
+++ b/segments/stack_project/stack_project.p9k
@@ -26,14 +26,11 @@
 ##
 prompt_stack_project() {
   local haskellstack_version=$(stack --version 2>/dev/null)
-  local content
   # Check for both a global Stack installation and a stack.yaml files (in current or parent directories)
   if [[ "${haskellstack_version}" =~ "([0-9.]+)" ]]; then
     local stackyaml_file_search=$(__p9k_upsearch "stack.yaml")
     if [[ "${stackyaml_file_search}" != "$HOME" && "${stackyaml_file_search}" != "/" ]]; then
-      content="Stack"
+      p9k::prepare_segment "${0}" "" "${1}" "${2}" "${3}" "Stack"
     fi
   fi
-
-  p9k::prepare_segment "${0}" "" "${1}" "${2}" "${3}" "${content}"
 }

--- a/segments/status/status.p9k
+++ b/segments/status/status.p9k
@@ -62,7 +62,7 @@ prompt_status() {
 
     for ec in "${(@)RETVALS[2,-1]}"; do
       ec_text="${ec_text}|$(exit_code_or_status "$ec")"
-      ec_sum=$(( $ec_sum + $ec ))
+      ec_sum=$(( ${ec_sum:-0} + ${ec:-0} ))
     done
   else
     # We use RETVAL instead of the right-most RETVALS item because
@@ -71,19 +71,13 @@ prompt_status() {
     ec_sum=${RETVAL}
   fi
 
-  local current_state
-  local content
   if (( ec_sum > 0 )); then
     if [[ "$P9K_STATUS_CROSS" == false && "$P9K_STATUS_VERBOSE" == true ]]; then
-      current_state="ERROR_CR"
-      content="${ec_text}"
+      p9k::prepare_segment "$0" "ERROR_CR" $1 "$2" $3 "$ec_text" "[[ true ]]"
     else
-      current_state="ERROR"
+      p9k::prepare_segment "$0" "ERROR" $1 "$2" $3 "" "[[ true ]]"
     fi
   elif [[ "$P9K_STATUS_OK" == true ]] && [[ "$P9K_STATUS_VERBOSE" == true || "$P9K_STATUS_OK_IN_NON_VERBOSE" == true ]]; then
-    current_state="OK"
+    p9k::prepare_segment "$0" "OK" $1 "$2" $3  "" "[[ true ]]"
   fi
-
-  p9k::prepare_segment "$0" "${current_state}" $1 "$2" $3  "${content}" \
-      "[[ \"${P9K_STATUS_VERBOSE}\" == \"true\" || \"${current_state}\" != \"OK\" ]]"
 }

--- a/segments/swift_version/swift_version.p9k
+++ b/segments/swift_version/swift_version.p9k
@@ -27,6 +27,7 @@
 prompt_swift_version() {
   # Get the first number as this is probably the "main" version number..
   local swift_version=$(swift --version 2>/dev/null | grep -o -E "[0-9.]+" | head -n 1)
+  [[ -z "${swift_version}" ]] && return
 
   p9k::prepare_segment "$0" "" $1 "$2" $3 "${swift_version}"
 }

--- a/segments/symfony2_tests/symfony2_tests.p9k
+++ b/segments/symfony2_tests/symfony2_tests.p9k
@@ -31,13 +31,11 @@ source $__P9K_DIRECTORY/segments/test_stats.p9k
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_symfony2_tests() {
-  local code_amount tests_amount
-  # Careful! `ls` seems to now work correctly with NULL_GLOB,
-  # as described here http://unix.stackexchange.com/a/26819
-  # This is the reason, why we do not use NULL_GLOB here.
-  code_amount=$({ls -1 src/**/*.php} 2> /dev/null | grep -vc Tests)
-  tests_amount=$({ls -1 src/**/*.php} 2> /dev/null | grep -c Tests)
+  if [[ (-d src && -d app && -f app/AppKernel.php) ]]; then
+    local code_amount tests_amount
+    code_amount=$(ls -1 src/**/*.php | grep -vc Tests)
+    tests_amount=$(ls -1 src/**/*.php | grep -c Tests)
 
-  build_test_stats "$0" "$1" $2 $3 "$code_amount" "$tests_amount" "SF2" \
-      "[[ (-d src && -d app && -f app/AppKernel.php && ${code_amount} -gt 0) ]]"
+    build_test_stats "$0" "$1" $2 $3 "$code_amount" "$tests_amount" "SF2"
+  fi
 }

--- a/segments/symfony2_version/symfony2_version.p9k
+++ b/segments/symfony2_version/symfony2_version.p9k
@@ -25,10 +25,9 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_symfony2_version() {
-  local symfony2_version
   if [[ -f app/bootstrap.php.cache ]]; then
+    local symfony2_version
     symfony2_version=$(grep " VERSION " app/bootstrap.php.cache | sed -e 's/[^.0-9]*//g')
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "$symfony2_version"
   fi
-
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "$symfony2_version"
 }

--- a/segments/todo/todo.p9k
+++ b/segments/todo/todo.p9k
@@ -25,13 +25,10 @@
 #   $3 boolean Whether the segment should be joined
 ##
 prompt_todo() {
-  local count
   if $(hash todo.sh 2>&-); then
     count=$(todo.sh ls | egrep "TODO: [0-9]+ of ([0-9]+) tasks shown" | awk '{ print $4 }')
-    if [[ "$count" != <-> ]]; then
-      count=''
+    if [[ "$count" = <-> ]]; then
+      p9k::prepare_segment "$0" "" $1 "$2" $3 "$count"
     fi
   fi
-
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "$count"
 }

--- a/segments/vagrant/vagrant.p9k
+++ b/segments/vagrant/vagrant.p9k
@@ -41,6 +41,7 @@ prompt_vagrant() {
     done
   done
 
-  p9k::prepare_segment "$0" ${current_state} $1 "$2" $3 "${current_string}" \
-      "[[ \"${current_state}\" != \"NOT_FOUND\" ]]"
+  if [[ "${current_state}" != "NOT_FOUND" ]]; then
+    p9k::prepare_segment "$0" ${current_state} $1 "$2" $3 "${current_string}"
+  fi
 }

--- a/segments/vcs/vcs.p9k
+++ b/segments/vcs/vcs.p9k
@@ -433,19 +433,20 @@ prompt_vcs() {
   vcs_info
   local vcs_prompt="${vcs_info_msg_0_}"
 
-  if [[ "${VCS_WORKDIR_CLOBBERED}" == true ]]; then
-    current_state='clobbered'
-  elif [[ "${VCS_WORKDIR_DIRTY}" == true ]]; then
-    current_state='modified'
-  else
-    if [[ "${VCS_WORKDIR_HALF_DIRTY}" == true ]]; then
-      current_state='untracked'
+  if [[ -n "${vcs_prompt}" ]]; then
+    if [[ "${VCS_WORKDIR_CLOBBERED}" == true ]]; then
+      current_state='clobbered'
+    elif [[ "${VCS_WORKDIR_DIRTY}" == true ]]; then
+      current_state='modified'
     else
-      current_state='clean'
+      if [[ "${VCS_WORKDIR_HALF_DIRTY}" == true ]]; then
+        current_state='untracked'
+      else
+        current_state='clean'
+      fi
     fi
+    p9k::prepare_segment ${0} ${current_state} ${1} "${2}" ${3} "${vcs_prompt}" "" "${vcs_segment_icon}"
   fi
-
-  p9k::prepare_segment ${0} ${current_state} ${1} "${2}" ${3} "${vcs_prompt}" "" "${vcs_segment_icon}" "[[ -n \"${vcs_prompt}\" ]]"
 }
 
 ################################################################

--- a/segments/vi_mode/vi_mode.p9k
+++ b/segments/vi_mode/vi_mode.p9k
@@ -77,17 +77,7 @@ prompt_vi_mode() {
 
 function rebuildViMode() {
   # Re-Init segment
-  for alignment in left right; do
-    for index in $(p9k::find_in_array "vi_mode" "${__P9K_DATA[${alignment}_segments]}"); do
-      local joined=false
-      local segmentMetaVar="P9K_${(U)alignment}_PROMPT_ELEMENTS[${index}]"
-      p9k::segment_is_tagged_as "joined" ${${(P)segmentMetaVar}%%::*} && joined=true
-      prompt_vi_mode "${alignment}" "${index}" "${joined}"
-      __p9k_refresh_cache_item "${__P9K_DATA[SEGMENT_RESULT]}"
-    done
-  done
-
-  __p9k_render "true"
+  __p9k_refresh_cache_item "vi_mode" "true"
 }
 
 ###############################################################

--- a/segments/virtualenv/virtualenv.p9k
+++ b/segments/virtualenv/virtualenv.p9k
@@ -28,5 +28,8 @@
 #   [virtualenv (Python)](https://virtualenv.pypa.io/en/latest/)
 #   for more information.
 prompt_virtualenv() {
+  # Early exit; $virtualenv_path must always be set.
+  [[ -z "${VIRTUAL_ENV:t}" ]] && return
+
   p9k::prepare_segment "$0" "" $1 "$2" $3 "${VIRTUAL_ENV:t}"
 }


### PR DESCRIPTION
This pr is based on the branch "fix-iteration-in-render", namely the former pr of mine.

I pre-empty the `${__P9K_DATA[SEGMENT_RESULT]}` to do an early exit without touching segments. Now the contributors could codes the segments without knowing the existence of async render. Early exit with single command `return` is acceptable now.

I've reverted most of the changes related early exit. Other irrelevant changes are kept. You'd better do a review carefully about the segments.